### PR TITLE
Add BattleOrders tardy check and quit/continue vars

### DIFF
--- a/d2bs/kolbot/libs/bots/BattleOrders.js
+++ b/d2bs/kolbot/libs/bots/BattleOrders.js
@@ -1,8 +1,8 @@
 /**
 *	@filename	BattleOrders.js
-*	@author		kolton
+*	@author		kolton, jmichelsen
 *	@desc		give or receive Battle Orders buff
-*   @return {boolean}
+*	@return {boolean}
 */
 
 function BattleOrders() {

--- a/d2bs/kolbot/libs/bots/BattleOrders.js
+++ b/d2bs/kolbot/libs/bots/BattleOrders.js
@@ -5,27 +5,29 @@
 *	@return {boolean}
 */
 
-function BattleOrders() {
-	this.checkForPlayers = function() {
+function BattleOrders () {
+	this.checkForPlayers = function () {
 		if (Misc.getPlayerCount() <= 1) {
 			throw new Error("Empty game"); // Alone in game
 		}
 	};
 
-	this.amTardy = function() {
+	this.amTardy = function () {
 		let party = getParty();
 
 		AreaInfoLoop:
 		while (true) {
 			try {
 				this.checkForPlayers();
-			} catch(e) {
+			} catch (e) {
 				if (Config.BattleOrders.Wait) {
-					print("Waiting " +Config.BattleOrders.Wait+ " seconds for other players...");
+					print("Waiting " + Config.BattleOrders.Wait + " seconds for other players...");
+
 					while (getTickCount() - tick < Config.BattleOrders.Wait * 1000) {
 						me.overhead("Waiting " + Math.round(((tick + (Config.BattleOrders.Wait * 1000)) - getTickCount()) / 1000) + " Seconds for other players");
 						delay(1000);
 					}
+
 					this.checkForPlayers();
 				}
 			}
@@ -44,14 +46,16 @@ function BattleOrders() {
 				if (party.area === 131 || party.area === 132 || party.area === 108 || party.area === 39) {
 					// Player is in Throne of Destruction, Worldstone Chamber, Chaos Sanctuary, or Cows
 					print("ÿc1I'm late to BOs. Moving on...");
+
 					return true;
 				}
 			} while (party.getNext());
 		}
+
 		return false; // Not late; wait.
 	};
 
-	this.giveBO = function(list) {
+	this.giveBO = function (list) {
 		let i,
 			unit,
 			failTimer = 60,
@@ -65,6 +69,7 @@ function BattleOrders() {
 					if (getTickCount() - tick >= failTimer * 1000) {
 						showConsole();
 						print("ÿc1BO timeout fail.");
+
 						if (Config.BattleOrders.QuitOnFailure) {
 							quit();
 						}
@@ -88,9 +93,11 @@ function BattleOrders() {
 	} catch (wperror) {
 		showConsole();
 		print("ÿc1Failed to take waypoint.");
+
 		if (Config.BattleOrders.QuitOnFailure) {
 			quit();
 		}
+
 		return false;
 	}
 
@@ -105,6 +112,7 @@ function BattleOrders() {
 		if (Config.BattleOrders.SkipIfTardy && this.amTardy()) {
 			break;
 		}
+
 		switch (Config.BattleOrders.Mode) {
 		case 0: // Give BO
 			for (i = 0; i < Config.BattleOrders.Getters.length; i += 1) {
@@ -112,9 +120,11 @@ function BattleOrders() {
 					if (getTickCount() - tick >= failTimer * 1000) {
 						showConsole();
 						print("ÿc1BO timeout fail.");
+
 						if (Config.BattleOrders.QuitOnFailure) {
 							quit();
 						}
+
 						break MainLoop;
 					}
 
@@ -137,9 +147,11 @@ function BattleOrders() {
 			if (getTickCount() - tick >= failTimer * 1000) {
 				showConsole();
 				print("ÿc1BO timeout fail.");
+
 				if (Config.BattleOrders.QuitOnFailure) {
 					quit();
 				}
+
 				break MainLoop;
 			}
 

--- a/d2bs/kolbot/libs/bots/BattleOrders.js
+++ b/d2bs/kolbot/libs/bots/BattleOrders.js
@@ -2,48 +2,58 @@
 *	@filename	BattleOrders.js
 *	@author		kolton
 *	@desc		give or receive Battle Orders buff
+*   @return {boolean}
 */
 
 function BattleOrders() {
-	this.AmTardy = function() {
-		let party;
+	this.checkForPlayers = function() {
+		if (Misc.getPlayerCount() <= 1) {
+			throw new Error("Empty game"); // Alone in game
+		}
+	};
 
-		if (Config.BattleOrders.SkipIfTardy) {
-			party = getParty();
+	this.amTardy = function() {
+		let party = getParty();
 
-			AreaInfoLoop:
-			while (true) {
-				if (Misc.getPlayerCount() <= 1) {
-					throw new Error("Empty game"); // Alone in game
+		AreaInfoLoop:
+		while (true) {
+			try {
+				this.checkForPlayers();
+			} catch(e) {
+				if (Config.BattleOrders.Wait) {
+					print("Waiting " +Config.BattleOrders.Wait+ " seconds for other players...");
+					while (getTickCount() - tick < Config.BattleOrders.Wait * 1000) {
+						me.overhead("Waiting " + Math.round(((tick + (Config.BattleOrders.Wait * 1000)) - getTickCount()) / 1000) + " Seconds for other players");
+						delay(1000);
+					}
+					this.checkForPlayers();
 				}
-
-				if (party) {
-					do {
-						if (party.name !== me.name && party.area) {
-							break AreaInfoLoop; // Can read player area
-						}
-					} while (party.getNext());
-				}
-
-				delay(1000);
 			}
 
 			if (party) {
 				do {
-					if (party.area === 131 || party.area === 132 || party.area === 108 || party.area === 39) { // Player is in Throne of Destruction or Worldstone Chamber or Chaos Sanctuary
-						print("ÿc1I'm late to BOs. Moving on...");
-						return true;
+					if (party.name !== me.name && party.area) {
+						break AreaInfoLoop; // Can read player area
 					}
 				} while (party.getNext());
-				return false; // Not late; wait.
 			}
-
 		}
-		return Config.BattleOrders.SkipIfTardy; // Not late; wait.
+
+		if (party) {
+			do {
+				if (party.area === 131 || party.area === 132 || party.area === 108 || party.area === 39) {
+					// Player is in Throne of Destruction, Worldstone Chamber, Chaos Sanctuary, or Cows
+					print("ÿc1I'm late to BOs. Moving on...");
+					return true;
+				}
+			} while (party.getNext());
+		}
+		return false; // Not late; wait.
 	};
 
-	this.giveBO = function (list) {
-		var i, unit,
+	this.giveBO = function(list) {
+		let i,
+			unit,
 			failTimer = 60,
 			tick = getTickCount();
 
@@ -55,11 +65,11 @@ function BattleOrders() {
 					if (getTickCount() - tick >= failTimer * 1000) {
 						showConsole();
 						print("ÿc1BO timeout fail.");
-						if (Config.BattleOrders.QuitOnFailedGive) {
+						if (Config.BattleOrders.QuitOnFailure) {
 							quit();
-						} else {
-							break;
 						}
+
+						break;
 					}
 
 					Precast.doPrecast(true);
@@ -78,7 +88,10 @@ function BattleOrders() {
 	} catch (wperror) {
 		showConsole();
 		print("ÿc1Failed to take waypoint.");
-		quit();
+		if (Config.BattleOrders.QuitOnFailure) {
+			quit();
+		}
+		return false;
 	}
 
 	Pather.moveTo(me.x + 6, me.y + 6);
@@ -87,25 +100,22 @@ function BattleOrders() {
 		tick = getTickCount(),
 		failTimer = 60;
 
-MainLoop:
+	MainLoop:
 	while (true) {
+		if (Config.BattleOrders.SkipIfTardy && this.amTardy()) {
+			break;
+		}
 		switch (Config.BattleOrders.Mode) {
 		case 0: // Give BO
-			if (this.AmTardy()) {
-				break MainLoop;
-			}
-
 			for (i = 0; i < Config.BattleOrders.Getters.length; i += 1) {
 				while (!Misc.inMyParty(Config.BattleOrders.Getters[i]) || !getUnit(0, Config.BattleOrders.Getters[i])) {
 					if (getTickCount() - tick >= failTimer * 1000) {
 						showConsole();
 						print("ÿc1BO timeout fail.");
-						if (Config.BattleOrders.QuitOnFailedGive) {
+						if (Config.BattleOrders.QuitOnFailure) {
 							quit();
-						} else {
-							break MainLoop;
 						}
-
+						break MainLoop;
 					}
 
 					delay(500);
@@ -124,18 +134,13 @@ MainLoop:
 				break MainLoop;
 			}
 
-			if (this.AmTardy()) {
-				break MainLoop;
-			}
-
 			if (getTickCount() - tick >= failTimer * 1000) {
 				showConsole();
 				print("ÿc1BO timeout fail.");
-				if (Config.BattleOrders.QuitOnFailedGet) {
+				if (Config.BattleOrders.QuitOnFailure) {
 					quit();
-				} else {
-					break MainLoop;
 				}
+				break MainLoop;
 			}
 
 			break;
@@ -146,7 +151,7 @@ MainLoop:
 
 	Pather.useWaypoint(1);
 
-	if (Config.BattleOrders.Mode === 0 && Config.BattleOrders.Wait) {
+	if (Config.BattleOrders.Mode === 0 && Config.BattleOrders.Idle) {
 		for (i = 0; i < Config.BattleOrders.Getters.length; i += 1) {
 			while (Misc.inMyParty(Config.BattleOrders.Getters[i])) {
 				delay(500);

--- a/d2bs/kolbot/libs/bots/BattleOrders.js
+++ b/d2bs/kolbot/libs/bots/BattleOrders.js
@@ -2,7 +2,6 @@
 *	@filename	BattleOrders.js
 *	@author		kolton, jmichelsen
 *	@desc		give or receive Battle Orders buff
-*	@return {boolean}
 */
 
 function BattleOrders () {

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -415,7 +415,10 @@ var Config = {
 	BattleOrders: {
 		Mode: 0,
 		Getters: [],
-		Wait: false
+		Wait: false,
+		QuitOnFailedGive: false,
+		QuitOnFailedGet: false,
+		SkipIfTardy: true
 	},
 	Enchant: {
 		Triggers: ["chant", "cows", "wps"],

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -415,10 +415,10 @@ var Config = {
 	BattleOrders: {
 		Mode: 0,
 		Getters: [],
-		Wait: false,
-		QuitOnFailedGive: false,
-		QuitOnFailedGet: false,
-		SkipIfTardy: true
+		Idle: false,  // Idle until player receiving BO leaves
+		QuitOnFailure: false,  // Quit the game if BO fails
+		SkipIfTardy: true,  // Proceed with scripts if other players already moved on from BO spot
+		Wait: 10,  // Duration to wait for players to join game
 	},
 	Enchant: {
 		Triggers: ["chant", "cows", "wps"],

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)tleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.


### PR DESCRIPTION
This removes the unnecessary delay when someone rejoins a game or joins
late and the time for battle orders has passed.

The bot will now check for other player locations and just continue on instead of waiting the
BattleOrder timeout. Instead of quitting if the timeout is reached, now the character can optionally just continue on with the run. These two changes combined make for smoother battle order control.