### PR TITLE
Added configuration to load other custom attack file.

### DIFF
--- a/d2bs/kolbot/libs/common/Attack.js
+++ b/d2bs/kolbot/libs/common/Attack.js
@@ -12,6 +12,9 @@ var Attack = {
 	init: function () {
 		if (Config.Wereform) {
 			include("common/Attacks/wereform.js");
+		} else if (Config.CustomClassAttack && FileTools.exists('libs/common/Attacks/'+Config.CustomClassAttack+'.js')) {
+			print('Loading custom attack file');
+			include('common/Attacks/'+Config.CustomClassAttack+'.js')
 		} else {
 			include("common/Attacks/" + this.classes[me.classid] + ".js");
 		}

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -317,6 +317,9 @@ var Config = {
 	AggressiveCloak: false,
 	SummonShadow: false,
 
+	// Custom Attack
+	CustomClassAttack: '', // If set it loads common/Attack/[CustomClassAttack].js
+
 	// Script specific
 	MFLeader: false,
 	Mausoleum: {


### PR DESCRIPTION
I often had the problem that i want something char specific.
Yet not override the original `common\attack\char.js`

However, there is no way to load any other custom class attack configuration without hacking into the core.

So, i added a configuration.
Config.CustomClassAttack, which if set loads a custom attack instead of the regular one, to have more customizable attacks if needed 